### PR TITLE
Fix handle option decorator

### DIFF
--- a/synda/cli/generate.py
+++ b/synda/cli/generate.py
@@ -19,10 +19,7 @@ def generate_command(
         False, "--retry", "-r", help="Run the pipeline from last failed step"
     ),
     run_id: Optional[int] = typer.Option(
-        None,
-        "--resume",
-        "-re",
-        help="Resume the pipeline from a given run id"
+        None, "--resume", "-re", help="Resume the pipeline from a given run id"
     ),
 ):
     """Run a pipeline with provided configuration."""

--- a/synda/cli/generate.py
+++ b/synda/cli/generate.py
@@ -27,9 +27,9 @@ def generate_command(
 ):
     """Run a pipeline with provided configuration."""
     if retry:
-        Pipeline.execute_from_last_failed_step()
+        Pipeline().execute_from_last_failed_step()
     elif run_id is not None:
-        Pipeline.resume(run_id=run_id)
+        Pipeline().resume(run_id=run_id)
     else:
         config = Config.load_config(config_file)
         pipeline = Pipeline(config)

--- a/synda/cli/generate.py
+++ b/synda/cli/generate.py
@@ -24,7 +24,7 @@ def generate_command(
 ):
     """Run a pipeline with provided configuration."""
     if retry:
-        Pipeline().execute_from_last_failed_step()
+        Pipeline().retry()
     elif run_id is not None:
         Pipeline().resume(run_id=run_id)
     else:

--- a/synda/model/node.py
+++ b/synda/model/node.py
@@ -71,6 +71,13 @@ class Node(SQLModel, table=True):
             [node for node in input_nodes_for_steps if node.id not in already_treated_input_nodes_ids],
             len(already_treated_input_nodes_ids)
         )
+    @staticmethod
+    def get_already_treated(session: Session, step: "Step") -> list["Node"]:
+        return session.exec(
+            select(Node)
+            .join(StepNode, Node.id == StepNode.node_id)
+            .where(and_(StepNode.step_id == step.id, StepNode.relationship_type == "output"))
+        ).fetchall()
 
     def is_ablated_text(self) -> str:
         return "yes" if self.ablated else "no"

--- a/synda/model/node.py
+++ b/synda/model/node.py
@@ -72,13 +72,5 @@ class Node(SQLModel, table=True):
             for node in input_nodes_for_steps
         ]
 
-    @staticmethod
-    def get_already_treated(session: Session, step: "Step") -> list["Node"]:
-        return session.exec(
-            select(Node)
-            .join(StepNode, Node.id == StepNode.node_id)
-            .where(and_(StepNode.step_id == step.id, StepNode.relationship_type == "output"))
-        ).fetchall()
-
     def is_ablated_text(self) -> str:
         return "yes" if self.ablated else "no"

--- a/synda/model/run.py
+++ b/synda/model/run.py
@@ -58,11 +58,11 @@ class Run(SQLModel, table=True):
         return run
 
     @staticmethod
-    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[Node], list[Step]]:
+    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[Node], list[Step], int]:
         run = Run.get_from_step(session, step)
         run.update(session, RunStatus.RUNNING)
-        input_nodes = Node.get_from_step(session, step)
-        return run, input_nodes, run.steps[step.position - 1 :]
+        input_nodes, already_treated_input_nodes = Node.get_from_step(session, step)
+        return run, input_nodes, run.steps[step.position - 1 :], already_treated_input_nodes
 
     def update(self, session: Session, status: RunStatus) -> "Run":
         self.status = status

--- a/synda/model/run.py
+++ b/synda/model/run.py
@@ -58,7 +58,7 @@ class Run(SQLModel, table=True):
         return run
 
     @staticmethod
-    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[tuple[Node, str]], list[Step]]:
+    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[Node], list[Step]]:
         run = Run.get_from_step(session, step)
         run.update(session, RunStatus.RUNNING)
         input_nodes = Node.get_input_nodes_from_step(session, step)

--- a/synda/model/run.py
+++ b/synda/model/run.py
@@ -58,11 +58,11 @@ class Run(SQLModel, table=True):
         return run
 
     @staticmethod
-    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[Node], list[Step], int]:
+    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[tuple[Node, str]], list[Step]]:
         run = Run.get_from_step(session, step)
         run.update(session, RunStatus.RUNNING)
-        input_nodes, already_treated_input_nodes = Node.get_from_step(session, step)
-        return run, input_nodes, run.steps[step.position - 1 :], already_treated_input_nodes
+        input_nodes = Node.get_input_nodes_from_step(session, step)
+        return run, input_nodes, run.steps[step.position - 1 :]
 
     def update(self, session: Session, status: RunStatus) -> "Run":
         self.status = status

--- a/synda/model/run.py
+++ b/synda/model/run.py
@@ -58,7 +58,9 @@ class Run(SQLModel, table=True):
         return run
 
     @staticmethod
-    def restart_from_step(session: Session, step: "Step") -> tuple["Run", list[Node], list[Step]]:
+    def restart_from_step(
+        session: Session, step: "Step"
+    ) -> tuple["Run", list[Node], list[Step]]:
         run = Run.get_from_step(session, step)
         run.update(session, RunStatus.RUNNING)
         input_nodes = Node.get_input_nodes_from_step(session, step)

--- a/synda/model/step.py
+++ b/synda/model/step.py
@@ -111,14 +111,10 @@ class Step(SQLModel, table=True):
     def set_completed_at_the_end(
         self, session: Session, input_nodes: list[Node], output_nodes: list[Node]
     ) -> "Step":
-        self.status = StepStatus.COMPLETED
-
         self._create_nodes_with_ancestors(session, input_nodes, output_nodes)
         self._map_nodes_to_step(session, output_nodes)
-        # print(f"Nodes saved: {input_nodes} --- {output_nodes}")
-        session.add(self)
-        session.commit()
-        session.refresh(self)
+
+        self.set_completed(session)
 
         return self
 

--- a/synda/model/step.py
+++ b/synda/model/step.py
@@ -71,9 +71,9 @@ class Step(SQLModel, table=True):
     @staticmethod
     def get_step_to_resume(session: Session, run_id: int) -> "Step":
         return session.exec(
-            select(Step).where(
-                and_(Step.status != StepStatus.COMPLETED, Step.run_id == run_id)
-            ).order_by(Step.position.asc())
+            select(Step)
+            .where(and_(Step.status != StepStatus.COMPLETED, Step.run_id == run_id))
+            .order_by(Step.position.asc())  # noqa
         ).first()
 
     def set_status(self, session: Session, status: str) -> "Step":
@@ -118,7 +118,9 @@ class Step(SQLModel, table=True):
 
         return self
 
-    def save_during_execution(self, session: Session, input_node: Node, output_node: Node) -> "Step":
+    def save_during_execution(
+        self, session: Session, input_node: Node, output_node: Node
+    ) -> "Step":
         self._create_nodes_with_ancestors(session, [input_node], [output_node])
         self._map_nodes_to_step(session, [output_node])
 

--- a/synda/model/step.py
+++ b/synda/model/step.py
@@ -108,7 +108,7 @@ class Step(SQLModel, table=True):
 
         return self
 
-    def set_completed_at_the_end(
+    def save_at_execution_end(
         self, session: Session, input_nodes: list[Node], output_nodes: list[Node]
     ) -> "Step":
         self._create_nodes_with_ancestors(session, input_nodes, output_nodes)
@@ -118,7 +118,7 @@ class Step(SQLModel, table=True):
 
         return self
 
-    def save_at_running(self, session: Session, input_node: Node, output_node: Node) -> "Step":
+    def save_during_execution(self, session: Session, input_node: Node, output_node: Node) -> "Step":
         self._create_nodes_with_ancestors(session, [input_node], [output_node])
         self._map_nodes_to_step(session, [output_node])
 
@@ -148,6 +148,9 @@ class Step(SQLModel, table=True):
             parent_node = next(node for node in input_nodes if node.id == parent_id)
             node.ancestors = parent_node.ancestors | {self.name: node.id}
             session.add(node)
+
+        for node in input_nodes:
+            node.set_processed(session)
 
     def _map_nodes_to_step(self, session: Session, output_nodes: list[Node]):
         for node in output_nodes:

--- a/synda/model/step_node.py
+++ b/synda/model/step_node.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Literal, TYPE_CHECKING
 
 from sqlmodel import SQLModel, Field, Relationship
@@ -7,14 +8,17 @@ if TYPE_CHECKING:
     from synda.model.node import Node
 
 
+class StepNodeRelationshipType(Enum):
+    INPUT = "input"
+    OUTPUT = "output"
+
+
 class StepNode(SQLModel, table=True):
     __tablename__ = "step_node"
 
     step_id: int = Field(foreign_key="step.id", primary_key=True)
     node_id: int = Field(foreign_key="node.id", primary_key=True)
-    relationship_type: str = Field(
-        index=True
-    )  # @todo add constraint for "input" or "output" only
+    relationship_type: StepNodeRelationshipType = Field(index=True)
 
     step: "Step" = Relationship(back_populates="step_node_links")
     node: "Node" = Relationship(back_populates="step_node_links")

--- a/synda/pipeline/ablation/llm_judge_binary.py
+++ b/synda/pipeline/ablation/llm_judge_binary.py
@@ -37,8 +37,8 @@ class LLMJudgeBinary(Executor):
 
         with self.progress.task(
             "  Ablating...",
-                (len(pending_nodes) + len(processed_nodes)) * len(criteria),
-                completed=len(processed_nodes) * len(criteria)
+            (len(pending_nodes) + len(processed_nodes)) * len(criteria),
+            completed=len(processed_nodes) * len(criteria),
         ) as advance_node:
             for node in pending_nodes:
                 judge_answers = []

--- a/synda/pipeline/ablation/llm_judge_binary.py
+++ b/synda/pipeline/ablation/llm_judge_binary.py
@@ -1,5 +1,5 @@
 import json
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 from sqlmodel import Session
@@ -31,14 +31,14 @@ class LLMJudgeBinary(Executor):
         self.model = self.config.parameters.model
 
     # @todo build criteria prompts in a single call
-    def execute(self, input_data: list[Node], n_treated: int = 0):
+    def execute(self, input_data: list[Node], already_treated: list[Node]):
         criteria = self.config.parameters.criteria
-        result = []
+        result = already_treated or []
 
         with self.progress.task(
             "  Ablating...",
-                len(input_data) * len(criteria) + (n_treated * len(criteria)),
-                completed=n_treated * len(criteria)
+                (len(input_data) + len(already_treated)) * len(criteria),
+                completed=len(already_treated) * len(criteria)
         ) as advance_node:
             for node in input_data:
                 judge_answers = []

--- a/synda/pipeline/ablation/llm_judge_binary.py
+++ b/synda/pipeline/ablation/llm_judge_binary.py
@@ -25,7 +25,7 @@ class LLMJudgeCriterionBinaryAnswer(BaseModel):
 
 class LLMJudgeBinary(Executor):
     def __init__(self, session: Session, run: Run, step_model: Step):
-        super().__init__(session, run, step_model, save_at_end=False)
+        super().__init__(session, run, step_model, save_on_completion=False)
         self.progress = ProgressManager("ABLATION")
         self.provider = Provider.get(self.config.parameters.provider)
         self.model = self.config.parameters.model

--- a/synda/pipeline/clean/deduplicates_tf_idf.py
+++ b/synda/pipeline/clean/deduplicates_tf_idf.py
@@ -14,16 +14,22 @@ class DeduplicateTFIDF(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("CLEAN")
 
-    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]) -> list[Node]:
+    def execute(
+        self, pending_nodes: list[Node], processed_nodes: list[Node]
+    ) -> list[Node]:
         strategy = self.config.parameters.strategy
         similarity_threshold = self.config.parameters.similarity_threshold
         keep = self.config.parameters.keep
 
         with self.progress.task(
-                "  Cleaning...", len(pending_nodes) + len(processed_nodes), completed=len(processed_nodes)
+            "  Cleaning...",
+            len(pending_nodes) + len(processed_nodes),
+            completed=len(processed_nodes),
         ) as advance:
             if strategy == "exact":
-                result_nodes = self._remove_exact_duplicates(pending_nodes, keep, advance)
+                result_nodes = self._remove_exact_duplicates(
+                    pending_nodes, keep, advance
+                )
             elif strategy == "fuzzy":
                 result_nodes = self._remove_fuzzy_duplicates(
                     pending_nodes, similarity_threshold, keep, advance

--- a/synda/pipeline/clean/deduplicates_tf_idf.py
+++ b/synda/pipeline/clean/deduplicates_tf_idf.py
@@ -14,12 +14,14 @@ class DeduplicateTFIDF(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("CLEAN")
 
-    def execute(self, input_data: list[Node], n_treated: int = 0) -> list[Node]:
+    def execute(self, input_data: list[Node], already_treated: list[Node]) -> list[Node]:
         strategy = self.config.parameters.strategy
         similarity_threshold = self.config.parameters.similarity_threshold
         keep = self.config.parameters.keep
 
-        with self.progress.task("  Cleaning...", len(input_data) + n_treated, completed=n_treated) as advance:
+        with self.progress.task(
+                "  Cleaning...", len(input_data) + len(already_treated), completed=len(already_treated)
+        ) as advance:
             if strategy == "exact":
                 result_nodes = self._remove_exact_duplicates(input_data, keep, advance)
             elif strategy == "fuzzy":

--- a/synda/pipeline/clean/deduplicates_tf_idf.py
+++ b/synda/pipeline/clean/deduplicates_tf_idf.py
@@ -14,12 +14,12 @@ class DeduplicateTFIDF(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("CLEAN")
 
-    def execute(self, input_data: list[Node]) -> list[Node]:
+    def execute(self, input_data: list[Node], n_treated: int = 0) -> list[Node]:
         strategy = self.config.parameters.strategy
         similarity_threshold = self.config.parameters.similarity_threshold
         keep = self.config.parameters.keep
 
-        with self.progress.task("  Cleaning...", len(input_data)) as advance:
+        with self.progress.task("  Cleaning...", len(input_data) + n_treated, completed=n_treated) as advance:
             if strategy == "exact":
                 result_nodes = self._remove_exact_duplicates(input_data, keep, advance)
             elif strategy == "fuzzy":

--- a/synda/pipeline/clean/deduplicates_tf_idf.py
+++ b/synda/pipeline/clean/deduplicates_tf_idf.py
@@ -14,38 +14,38 @@ class DeduplicateTFIDF(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("CLEAN")
 
-    def execute(self, input_data: list[Node], already_treated: list[Node]) -> list[Node]:
+    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]) -> list[Node]:
         strategy = self.config.parameters.strategy
         similarity_threshold = self.config.parameters.similarity_threshold
         keep = self.config.parameters.keep
 
         with self.progress.task(
-                "  Cleaning...", len(input_data) + len(already_treated), completed=len(already_treated)
+                "  Cleaning...", len(pending_nodes) + len(processed_nodes), completed=len(processed_nodes)
         ) as advance:
             if strategy == "exact":
-                result_nodes = self._remove_exact_duplicates(input_data, keep, advance)
+                result_nodes = self._remove_exact_duplicates(pending_nodes, keep, advance)
             elif strategy == "fuzzy":
                 result_nodes = self._remove_fuzzy_duplicates(
-                    input_data, similarity_threshold, keep, advance
+                    pending_nodes, similarity_threshold, keep, advance
                 )
 
         return [Node(parent_node_id=node.id, value=node.value) for node in result_nodes]
 
     @staticmethod
     def _remove_exact_duplicates(
-        input_data: list[Node], keep: str, advance
+        pending_nodes: list[Node], keep: str, advance
     ) -> list[Node]:
         seen_values = set()
         result = []
 
         if keep == "first":
-            for node in input_data:
+            for node in pending_nodes:
                 if node.value not in seen_values:
                     seen_values.add(node.value)
                     result.append(node)
                 advance()
         elif keep == "last":
-            for node in reversed(input_data):
+            for node in reversed(pending_nodes):
                 if node.value not in seen_values:
                     seen_values.add(node.value)
                     result.insert(0, node)
@@ -55,9 +55,9 @@ class DeduplicateTFIDF(Executor):
 
     @staticmethod
     def _remove_fuzzy_duplicates(
-        input_data: list[Node], similarity_threshold: float, keep: str, advance
+        pending_nodes: list[Node], similarity_threshold: float, keep: str, advance
     ) -> list[Node]:
-        node_values = [node.value for node in input_data]
+        node_values = [node.value for node in pending_nodes]
 
         vectorizer = TfidfVectorizer(strip_accents="unicode")
         tfidf_matrix = vectorizer.fit_transform(node_values)
@@ -84,4 +84,4 @@ class DeduplicateTFIDF(Executor):
 
             advance()
 
-        return [input_data[i] for i in sorted(index_node_to_keep)]
+        return [pending_nodes[i] for i in sorted(index_node_to_keep)]

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Optional
 
 from sqlmodel import Session
 
@@ -17,14 +16,14 @@ class Executor:
         self.save_at_end = save_at_end
 
     def execute_and_update_step(
-        self, input_nodes: list[Node], already_treated: list[Node], restarted: bool = False
+        self, pending_nodes: list[Node], processed_nodes: list[Node], restarted: bool = False
     ) -> list[Node]:
         try:
-            self.step_model.set_running(self.session, input_nodes, restarted=restarted)
+            self.step_model.set_running(self.session, pending_nodes, restarted=restarted)
 
-            output_nodes = self.execute(input_nodes, already_treated)
+            output_nodes = self.execute(pending_nodes, processed_nodes)
             if self.save_at_end:
-                self.step_model.set_completed_at_the_end(self.session, input_nodes, output_nodes)
+                self.step_model.save_at_execution_end(self.session, pending_nodes, output_nodes)
             else:
                 self.step_model.set_completed(session=self.session)
 
@@ -36,5 +35,5 @@ class Executor:
             raise e
 
     @abstractmethod
-    def execute(self, input_data: list[Node], already_treated: list[Node]):
+    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]):
         pass

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -25,11 +25,11 @@ class Executor:
         self,
         pending_nodes: list[Node],
         processed_nodes: list[Node],
-        restarted: bool = False,
+        restarted_step: bool = False,
     ) -> list[Node]:
         try:
             self.step_model.set_running(
-                self.session, pending_nodes, restarted=restarted
+                self.session, pending_nodes, restarted=restarted_step
             )
 
             output_nodes = self.execute(pending_nodes, processed_nodes)

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -8,7 +8,13 @@ from synda.model.node import Node
 
 
 class Executor:
-    def __init__(self, session: Session, run: Run, step_model: Step, save_on_completion: bool=True):
+    def __init__(
+        self,
+        session: Session,
+        run: Run,
+        step_model: Step,
+        save_on_completion: bool = True,
+    ):
         self.session = session
         self.run = run
         self.step_model = step_model
@@ -16,14 +22,21 @@ class Executor:
         self.save_on_completion = save_on_completion
 
     def execute_and_update_step(
-        self, pending_nodes: list[Node], processed_nodes: list[Node], restarted: bool = False
+        self,
+        pending_nodes: list[Node],
+        processed_nodes: list[Node],
+        restarted: bool = False,
     ) -> list[Node]:
         try:
-            self.step_model.set_running(self.session, pending_nodes, restarted=restarted)
+            self.step_model.set_running(
+                self.session, pending_nodes, restarted=restarted
+            )
 
             output_nodes = self.execute(pending_nodes, processed_nodes)
             if self.save_on_completion:
-                self.step_model.save_at_execution_end(self.session, pending_nodes, output_nodes)
+                self.step_model.save_at_execution_end(
+                    self.session, pending_nodes, output_nodes
+                )
             else:
                 self.step_model.set_completed(session=self.session)
 

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -8,12 +8,12 @@ from synda.model.node import Node
 
 
 class Executor:
-    def __init__(self, session: Session, run: Run, step_model: Step, save_at_end: bool=True):
+    def __init__(self, session: Session, run: Run, step_model: Step, save_on_completion: bool=True):
         self.session = session
         self.run = run
         self.step_model = step_model
         self.config = step_model.get_step_config()
-        self.save_at_end = save_at_end
+        self.save_on_completion = save_on_completion
 
     def execute_and_update_step(
         self, pending_nodes: list[Node], processed_nodes: list[Node], restarted: bool = False
@@ -22,7 +22,7 @@ class Executor:
             self.step_model.set_running(self.session, pending_nodes, restarted=restarted)
 
             output_nodes = self.execute(pending_nodes, processed_nodes)
-            if self.save_at_end:
+            if self.save_on_completion:
                 self.step_model.save_at_execution_end(self.session, pending_nodes, output_nodes)
             else:
                 self.step_model.set_completed(session=self.session)

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -8,21 +8,24 @@ from synda.model.node import Node
 
 
 class Executor:
-    def __init__(self, session: Session, run: Run, step_model: Step):
+    def __init__(self, session: Session, run: Run, step_model: Step, save_at_end: bool=True):
         self.session = session
         self.run = run
         self.step_model = step_model
         self.config = step_model.get_step_config()
+        self.save_at_end = save_at_end
 
     def execute_and_update_step(
-        self, input_nodes: list[Node], restarted: bool = False
+        self, input_nodes: list[Node], restarted: bool = False, n_treated: int = 0
     ) -> list[Node]:
         try:
             self.step_model.set_running(self.session, input_nodes, restarted=restarted)
 
-            output_nodes = self.execute(input_nodes)
-
-            self.step_model.set_completed(self.session, input_nodes, output_nodes)
+            output_nodes = self.execute(input_nodes, n_treated)
+            if self.save_at_end:
+                self.step_model.set_completed_at_the_end(self.session, input_nodes, output_nodes)
+            else:
+                self.step_model.set_completed(session=self.session)
 
             filtered_nodes = [node for node in output_nodes if not node.ablated]
 
@@ -32,5 +35,5 @@ class Executor:
             raise e
 
     @abstractmethod
-    def execute(self, input_data: list[Node]):
+    def execute(self, input_data: list[Node], n_treated: int = 0):
         pass

--- a/synda/pipeline/executor.py
+++ b/synda/pipeline/executor.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Optional
 
 from sqlmodel import Session
 
@@ -16,12 +17,12 @@ class Executor:
         self.save_at_end = save_at_end
 
     def execute_and_update_step(
-        self, input_nodes: list[Node], restarted: bool = False, n_treated: int = 0
+        self, input_nodes: list[Node], already_treated: list[Node], restarted: bool = False
     ) -> list[Node]:
         try:
             self.step_model.set_running(self.session, input_nodes, restarted=restarted)
 
-            output_nodes = self.execute(input_nodes, n_treated)
+            output_nodes = self.execute(input_nodes, already_treated)
             if self.save_at_end:
                 self.step_model.set_completed_at_the_end(self.session, input_nodes, output_nodes)
             else:
@@ -35,5 +36,5 @@ class Executor:
             raise e
 
     @abstractmethod
-    def execute(self, input_data: list[Node], n_treated: int = 0):
+    def execute(self, input_data: list[Node], already_treated: list[Node]):
         pass

--- a/synda/pipeline/generation/llm.py
+++ b/synda/pipeline/generation/llm.py
@@ -13,7 +13,7 @@ from synda.progress_manager import ProgressManager
 
 class LLM(Executor):
     def __init__(self, session: Session, run: Run, step_model: Step):
-        super().__init__(session, run, step_model, save_at_end=False)
+        super().__init__(session, run, step_model, save_on_completion=False)
         self.progress = ProgressManager("GENERATION")
         self.provider = Provider.get(self.config.parameters.provider)
         self.model = self.config.parameters.model

--- a/synda/pipeline/generation/llm.py
+++ b/synda/pipeline/generation/llm.py
@@ -1,4 +1,3 @@
-
 from sqlmodel import Session
 
 from synda.model.provider import Provider
@@ -28,7 +27,9 @@ class LLM(Executor):
         )
         result = processed_nodes
         with self.progress.task(
-                "Generating...", len(pending_nodes) + len(processed_nodes), completed=len(processed_nodes)
+            "Generating...",
+            len(pending_nodes) + len(processed_nodes),
+            completed=len(processed_nodes),
         ) as advance:
             for node, prompt in zip(pending_nodes, prompts):
                 llm_answer = LLMProvider.call(
@@ -47,7 +48,9 @@ class LLM(Executor):
         return result
 
     @staticmethod
-    def _build_node_occurrences(pending_nodes: list[Node], occurrences: int) -> list[Node]:
+    def _build_node_occurrences(
+        pending_nodes: list[Node], occurrences: int
+    ) -> list[Node]:
         nodes = []
 
         for node in pending_nodes:

--- a/synda/pipeline/generation/llm.py
+++ b/synda/pipeline/generation/llm.py
@@ -25,7 +25,7 @@ class LLM(Executor):
         prompts = PromptBuilder.build(
             self.session, template, input_data, instruction_sets=instruction_sets
         )
-        result = []
+        result = Node.get_already_treated(self.session, self.step_model) if n_treated > 0 else []
         with self.progress.task("Generating...", len(input_data) + n_treated, completed=n_treated) as advance:
             for node, prompt in zip(input_data, prompts):
                 llm_answer = LLMProvider.call(

--- a/synda/pipeline/metadata/word_position.py
+++ b/synda/pipeline/metadata/word_position.py
@@ -16,7 +16,7 @@ class WordPosition(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("METADATA")
 
-    def execute(self, input_data: list[Node]):
+    def execute(self, input_data: list[Node], n_treated: int = 0):
         result = []
         matches = self.config.parameters.matches
 

--- a/synda/pipeline/metadata/word_position.py
+++ b/synda/pipeline/metadata/word_position.py
@@ -16,7 +16,7 @@ class WordPosition(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("METADATA")
 
-    def execute(self, input_data: list[Node], n_treated: int = 0):
+    def execute(self, input_data: list[Node], already_treated: list[Node]):
         result = []
         matches = self.config.parameters.matches
 

--- a/synda/pipeline/metadata/word_position.py
+++ b/synda/pipeline/metadata/word_position.py
@@ -16,12 +16,12 @@ class WordPosition(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("METADATA")
 
-    def execute(self, input_data: list[Node], already_treated: list[Node]):
+    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]):
         result = []
         matches = self.config.parameters.matches
 
-        with self.progress.task("  Metadata...", len(input_data)) as advance:
-            for node in input_data:
+        with self.progress.task("  Metadata...", len(pending_nodes)) as advance:
+            for node in pending_nodes:
                 metadata = []
                 text = node.value
 

--- a/synda/pipeline/pipeline.py
+++ b/synda/pipeline/pipeline.py
@@ -117,7 +117,7 @@ class Pipeline:
 
         resumed_step = Step.get_step_to_resume(session=self.session, run_id=run_id)
 
-        self.run, input_nodes, remaining_steps = Run.restart_from_step(session=self.session, step=resumed_step)
+        self.run, input_nodes, remaining_steps, treated = Run.restart_from_step(session=self.session, step=resumed_step)
         self.config = Config.model_validate(self.run.config)
         self.output_saver = self.config.output.get_saver()
         for step_ in remaining_steps:
@@ -127,7 +127,7 @@ class Pipeline:
             executor = step_.get_step_config().get_executor(
                 self.session, self.run, step_
             )
-            input_nodes = executor.execute_and_update_step(input_nodes, restarted=True)
+            input_nodes = executor.execute_and_update_step(input_nodes, restarted=True, n_treated=treated)
 
         self.output_saver.save(input_nodes)
 

--- a/synda/pipeline/pipeline.py
+++ b/synda/pipeline/pipeline.py
@@ -82,11 +82,11 @@ class Pipeline:
 
 
     @handle_run_errors
+    @handle_stop_option
     def execute_from_last_failed_step(self):
         from synda.config import Config
         CONSOLE.print("[blue]Retrying last failed run")
 
-        # session = Session(engine)
         last_failed_step = Step.get_last_failed(self.session)
 
         if last_failed_step is None:
@@ -114,7 +114,6 @@ class Pipeline:
         from synda.config import Config
         CONSOLE.print(f"[blue]Resuming run {run_id}")
 
-        # session = Session(engine)
         resumed_step = Step.get_step_to_resume(session=self.session, run_id=run_id)
 
         self.run, input_nodes, remaining_steps = Run.restart_from_step(session=self.session, step=resumed_step)

--- a/synda/pipeline/pipeline.py
+++ b/synda/pipeline/pipeline.py
@@ -120,6 +120,7 @@ class Pipeline:
         self.run, input_nodes, remaining_steps, treated = Run.restart_from_step(session=self.session, step=resumed_step)
         self.config = Config.model_validate(self.run.config)
         self.output_saver = self.config.output.get_saver()
+        restarted = True
         for step_ in remaining_steps:
             if is_debug_enabled():
                 print(step_)
@@ -127,7 +128,9 @@ class Pipeline:
             executor = step_.get_step_config().get_executor(
                 self.session, self.run, step_
             )
-            input_nodes = executor.execute_and_update_step(input_nodes, restarted=True, n_treated=treated)
+            input_nodes = executor.execute_and_update_step(input_nodes, restarted=restarted, n_treated=treated)
+            treated = 0
+            restarted = False
 
         self.output_saver.save(input_nodes)
 

--- a/synda/pipeline/pipeline.py
+++ b/synda/pipeline/pipeline.py
@@ -65,7 +65,7 @@ class Pipeline:
     def execute(self):
         if self.config is None:
             raise ValueError("Config can't be None to execute a pipeline")
-        # self.run = Run.create_with_steps(self.session, self.config)
+
         input_nodes = self.input_loader.load(self.session)
 
         for step in self.run.steps:

--- a/synda/pipeline/split/chunk.py
+++ b/synda/pipeline/split/chunk.py
@@ -12,7 +12,7 @@ class Chunk(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node]):
+    def execute(self, input_data: list[Node], n_treated: int = 0):
         result = []
         size = self.config.parameters.size
 

--- a/synda/pipeline/split/chunk.py
+++ b/synda/pipeline/split/chunk.py
@@ -12,12 +12,12 @@ class Chunk(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node], already_treated: list[Node]):
+    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]):
         result = []
         size = self.config.parameters.size
 
-        with self.progress.task("  Chunking...", len(input_data)) as advance:
-            for node in input_data:
+        with self.progress.task("  Chunking...", len(pending_nodes)) as advance:
+            for node in pending_nodes:
                 text = node.value
 
                 while text:

--- a/synda/pipeline/split/chunk.py
+++ b/synda/pipeline/split/chunk.py
@@ -12,7 +12,7 @@ class Chunk(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node], n_treated: int = 0):
+    def execute(self, input_data: list[Node], already_treated: list[Node]):
         result = []
         size = self.config.parameters.size
 

--- a/synda/pipeline/split/separator.py
+++ b/synda/pipeline/split/separator.py
@@ -12,13 +12,13 @@ class Separator(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node], already_treated: list[Node]):
+    def execute(self, pending_nodes: list[Node], processed_nodes: list[Node]):
         result = []
         separator = self.config.parameters.separator
         keep_separator = self.config.parameters.keep_separator
 
-        with self.progress.task("Separating...", len(input_data)) as advance:
-            for node in input_data:
+        with self.progress.task("Separating...", len(pending_nodes)) as advance:
+            for node in pending_nodes:
                 text = node.value
                 start = 0
                 pos = text.find(separator)

--- a/synda/pipeline/split/separator.py
+++ b/synda/pipeline/split/separator.py
@@ -12,7 +12,7 @@ class Separator(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node]):
+    def execute(self, input_data: list[Node], n_treated: int = 0):
         result = []
         separator = self.config.parameters.separator
         keep_separator = self.config.parameters.keep_separator

--- a/synda/pipeline/split/separator.py
+++ b/synda/pipeline/split/separator.py
@@ -12,7 +12,7 @@ class Separator(Executor):
         super().__init__(session, run, step_model)
         self.progress = ProgressManager("SPLIT")
 
-    def execute(self, input_data: list[Node], n_treated: int = 0):
+    def execute(self, input_data: list[Node], already_treated: list[Node]):
         result = []
         separator = self.config.parameters.separator
         keep_separator = self.config.parameters.keep_separator

--- a/synda/progress_manager.py
+++ b/synda/progress_manager.py
@@ -34,7 +34,7 @@ class ProgressManager:
         )
 
     @contextmanager
-    def task(self, description: str, total: int, transient: bool = False):
+    def task(self, description: str, total: int, completed: int = 0, transient: bool = False):
         with self.progress as progress:
-            task_id = progress.add_task(description, total=total, transient=transient)
+            task_id = progress.add_task(description, total=total, transient=transient, completed=completed)
             yield lambda: progress.advance(task_id)

--- a/synda/progress_manager.py
+++ b/synda/progress_manager.py
@@ -34,7 +34,11 @@ class ProgressManager:
         )
 
     @contextmanager
-    def task(self, description: str, total: int, completed: int = 0, transient: bool = False):
+    def task(
+        self, description: str, total: int, completed: int = 0, transient: bool = False
+    ):
         with self.progress as progress:
-            task_id = progress.add_task(description, total=total, transient=transient, completed=completed)
+            task_id = progress.add_task(
+                description, total=total, transient=transient, completed=completed
+            )
             yield lambda: progress.advance(task_id)

--- a/tests/stubs/ollama_rag/config.yaml
+++ b/tests/stubs/ollama_rag/config.yaml
@@ -24,7 +24,7 @@ pipeline:
     parameters:
       provider: ollama
       model: llama3.2
-      occurrences: 6
+      occurrences: 1
       template: |
         Ask a question regarding the sentence about the content.
         content: {chunk_faq}


### PR DESCRIPTION
Fix PR to answer [this issue](https://github.com/timothepearce/synda/issues/17).
Proposition to enhance the `--resume` option by saving step results during compute

**Features in this PR**
- Add `handle_stop_option` decorator to `resume` method for `Pipeline` class
- Make the `resume` and `execute_from_last_failed_step` instance methods
- Move `handle_run_errors` and `handle_stop_option` decorators into `Pipeline` class and make them static
- Add `save_at_completion` attribute to `Executor` abstract class (this lets each child class to determine if results are saved at the end of execution or during execution)
- Add `processed_nodes` arg to `execute` method of `Executor` class to resume a run at node level (from the first untreated node in resumed step) instead of step level
- Adapt all step classes in *synda/pipeline* to match the new definition of `Executor class`
- Adapt `LLM` and `LLMJudgeBinary` classes to let them save results during execution