### PR TITLE
Add the pdf input type support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ sqlmodel = "^0.0.22"
 typer = {extras = ["all"], version = "^0.15.1"}
 scikit-learn = "^1.6.1"
 openpyxl = "^3.1.5"
+pypdf2 = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/synda/config/input/input.py
+++ b/synda/config/input/input.py
@@ -4,14 +4,15 @@ from pydantic import BaseModel
 
 from synda.config.input.csv import CSVInputProperties
 from synda.config.input.xls import XLSInputProperties
+from synda.config.input.pdf import PDFInputProperties
 from synda.config.input.database import DatabaseInputProperties
 
 from synda.pipeline.input import InputLoader
 
 
 class Input(BaseModel):
-    type: Literal["csv", "xls"]
-    properties: CSVInputProperties | XLSInputProperties  # | DatabaseSourceProperties
+    type: Literal["csv", "xls", "pdf"]
+    properties: CSVInputProperties | XLSInputProperties | PDFInputProperties  # | DatabaseSourceProperties
 
     def get_loader(self) -> InputLoader:
         if self.type == "csv":
@@ -22,3 +23,7 @@ class Input(BaseModel):
             from synda.pipeline.input.xls_input_loader import XLSInputLoader
 
             return XLSInputLoader(self)
+        elif self.type == "pdf":
+            from synda.pipeline.input.pdf_input_loader import PDFInputLoader
+            
+            return PDFInputLoader(self)

--- a/synda/config/input/pdf.py
+++ b/synda/config/input/pdf.py
@@ -1,0 +1,48 @@
+import os
+from typing import List
+
+import PyPDF2
+from pydantic import model_validator, Field
+
+from synda.config.input.input_properties import InputProperties
+
+
+class PDFInputProperties(InputProperties):
+    path: str
+    pages: List[str] = Field(default_factory=list)  # Ex: ["1-10", "14-16", "19"]
+
+    @model_validator(mode="after")
+    def validate_properties(self) -> "PDFInputProperties":
+        self._validate_path()
+        self._validate_file()
+        return self
+
+    def _validate_path(self) -> None:
+        if not os.path.isfile(self.path):
+            raise ValueError(f"Source file does not exist: {self.path}")
+
+    def _validate_file(self) -> None:
+        try:
+            with open(self.path, 'rb') as file:
+                reader = PyPDF2.PdfReader(file)
+                if len(reader.pages) == 0:
+                    raise ValueError(f"PDF file is empty: {self.path}")
+        except Exception as e:
+            raise ValueError(f"Unable to parse PDF file: {self.path}. Error: {str(e)}")
+
+    def get_page_indices(self, total_pages: int) -> list[int]:
+        """
+        Convertit la liste de plages de pages en liste d'index (1-based).
+        Si pages est vide, retourne toutes les pages.
+        """
+        if not self.pages:
+            return list(range(total_pages))
+        indices = set()
+        for entry in self.pages:
+            if '-' in entry:
+                start, end = entry.split('-')
+                indices.update(range(int(start)-1, int(end)))
+            else:
+                indices.add(int(entry)-1)
+        # On filtre les index hors bornes
+        return [i for i in sorted(indices) if 0 <= i < total_pages]

--- a/synda/pipeline/input/pdf_input_loader.py
+++ b/synda/pipeline/input/pdf_input_loader.py
@@ -1,0 +1,37 @@
+import PyPDF2
+
+from sqlmodel import Session
+
+from synda.pipeline.input import InputLoader
+from synda.config.input import Input
+from synda.model.node import Node
+
+
+class PDFInputLoader(InputLoader):
+    def __init__(self, input_config: Input):
+        self.properties = input_config.properties
+        super().__init__()
+
+    def load(self, session: Session) -> list[Node]:
+        result = []
+        
+        with open(self.properties.path, 'rb') as file:
+            reader = PyPDF2.PdfReader(file)
+            total_pages = len(reader.pages)
+            page_indices = self.properties.get_page_indices(total_pages)
+            
+            for page_num in page_indices:
+                page = reader.pages[page_num]
+                text = page.extract_text()
+                
+                # Create one node per page with the extracted text
+                result.append(Node(value=text, node_metadata=[{
+                    "source_type": "pdf",
+                    "source_path": self.properties.path,
+                    "page_number": page_num + 1,
+                    "total_pages": total_pages
+                }]))
+
+        self.persist_nodes(session, result)
+
+        return result


### PR DESCRIPTION
With it, every pdf file stored locally can be used as an input
Two parameters can be passed 
```
input:
  type: pdf
  properties:
    path: tests/stubs/simple_pipeline/lol.pdf
    pages: ["8-16", "18"]
```

`path` : the local path to the file
`pages`: an indices file which defines the pages you want to extract from the pdf (if empty or not passed, the entire pdf is processed)

For the moment, the text is extracted via PyPDF2, we can implement a vision method also
A node is a page of the pdf and the value stored in it is its extracted text