### PR TITLE
Fix validator output ; rename import to not duplicate base class

### DIFF
--- a/synda/config/step.py
+++ b/synda/config/step.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from pydantic import BaseModel, model_validator
 from sqlmodel import Session
 
 from synda.model.run import Run
-from synda.model.step import Step
+from synda.model.step import Step as ModelStep
 
 if TYPE_CHECKING:
     from synda.pipeline.executor import Executor
@@ -18,11 +20,12 @@ class Step(BaseModel, ABC):
     parameters: dict
 
     @model_validator(mode="after")
-    def set_default_name(self) -> str:
+    def set_default_name(self) -> Self:
         if self.name is None:
             self.name = f"{self.type}_{self.method}"
         return self
 
     @abstractmethod
-    def get_executor(self, session: Session, run: Run, step_model: Step) -> "Executor":
-        pass
+    def get_executor(
+        self, session: Session, run: Run, step_model: ModelStep
+    ) -> Executor: ...


### PR DESCRIPTION
`synda/config/step.py` 

 * Remove import that override the main class of the file
 * `@model_validator` should return Self and not str (https://docs.pydantic.dev/latest/concepts/validators/#model-after-validator)
 * Use `from __future__ import annotations` so we don't have to put `Executor` between quotes. 
 
 @timothepearce probably we could improve the typing of parameters, what is it supposed to be?